### PR TITLE
Inject trackingcode

### DIFF
--- a/qiita_core/configuration_manager.py
+++ b/qiita_core/configuration_manager.py
@@ -127,6 +127,11 @@ class ConfigurationManager(object):
         The email address a user should write to when asking for help
     sysadmin_email : str
         The email address, Qiita sends internal notifications to a sys admin
+    tracking_js_code : str
+        You might want to track user on your Qiita instance. The content of the
+        JS_CODE variable will inject this JavaScript code to the sitebase.html
+        template, which means it will be added to basically every page of
+        Qiita.
 
     Raises
     ------
@@ -162,6 +167,7 @@ class ConfigurationManager(object):
         self._get_vamps(config)
         self._get_portal(config)
         self._iframe(config)
+        self._get_tracking(config)
 
     def _get_main(self, config):
         """Get the configuration of the main section"""
@@ -390,3 +396,11 @@ class ConfigurationManager(object):
 
     def _iframe(self, config):
         self.iframe_qiimp = config.get('iframe', 'QIIMP', fallback=None)
+
+    def _get_tracking(self, config):
+        """Get the configuration of the 'user_tracking' section"""
+
+        self.tracking_js_code = config.get(
+            'user_tracking', 'JS_CODE', fallback=None)
+        if not self.tracking_js_code:
+            self.tracking_js_code = None

--- a/qiita_core/support_files/config_test.cfg
+++ b/qiita_core/support_files/config_test.cfg
@@ -196,3 +196,10 @@ STATS_MAP_CENTER_LONGITUDE =
 # On May 2024, we removed QIIMP from the code base but we will leave this
 # section in case we need to add access to another iframe in the future; note
 # that the qiita-terms are also accessed via iframe but this is internal
+
+# ----------------------------- User tracking Settings ---------------------
+[user_tracking]
+# You might want to track user on your Qiita instance. You can here inject
+# JavaScript code to the sitebase.html template, which means it will be added
+# to basically every page of Qiita.
+JS_CODE =

--- a/qiita_core/tests/test_configuration_manager.py
+++ b/qiita_core/tests/test_configuration_manager.py
@@ -289,6 +289,23 @@ class ConfigurationManagerTests(TestCase):
         obs._get_portal(self.conf)
         self.assertEqual(obs.stats_map_center_longitude, -105.24827)
 
+    def test_get_tracking(self):
+        obs = ConfigurationManager()
+
+        # test for multi line content
+        self.assertTrue(len(obs.tracking_js_code) > 520)
+        self.assertIn("['setTrackerUrl'", obs.tracking_js_code)
+
+        # test that None is returned, if JS_CODE in config file, but not set
+        self.conf.set('user_tracking', 'JS_CODE', "")
+        obs._get_tracking(self.conf)
+        self.assertEqual(obs.tracking_js_code, None)
+
+        # test that if JS_CODE is not in config file, result in None
+        self.conf.remove_option('user_tracking', 'JS_CODE')
+        obs._get_tracking(self.conf)
+        self.assertEqual(obs.tracking_js_code, None)
+
 
 CONF = """
 # ------------------------------ Main settings --------------------------------
@@ -471,6 +488,25 @@ STATS_MAP_CENTER_LONGITUDE =
 
 # ----------------------------- iframes settings ---------------------------
 [iframe]
+# ----------------------------- User tracking Settings ---------------------
+[user_tracking]
+# You might want to track user on your Qiita instance. You can here inject
+# JavaScript code to the sitebase.html template, which means it will be added
+# to basically every page of Qiita.
+JS_CODE = <!-- Matomo --><script>var _paq = window._paq = window._paq || [];
+  /* tracker methods like "setCustomDimension" should be called before
+     "trackPageView" */
+  _paq.push(['trackPageView']);_paq.push(['enableLinkTracking']);
+  (function() {var u="https://piwik.cebitec.uni-bielefeld.de/";_
+  paq.push(['setTrackerUrl', u+'matomo.php']);_
+  paq.push(['setSiteId', '21']);
+  var d=document, g=d.createElement('script'), s=d.getElementsByTagName(
+    'script')[0];
+  g.async=true;
+  g.src=u+'matomo.js';
+  s.parentNode.insertBefore(g,s);})();
+  </script><!-- End Matomo Code -->
+
 """
 
 if __name__ == '__main__':

--- a/qiita_pet/templates/sitebase.html
+++ b/qiita_pet/templates/sitebase.html
@@ -334,6 +334,9 @@
   </head>
 
   <body style="padding-top: 70px; height: 100%" onload='overlay_check();'>
+    {% if qiita_config.tracking_js_code is not None %}
+      {% raw qiita_config.tracking_js_code %}
+    {% end %}
 
     <div id="qiita-main" class="qiita-main">
       <div id="navigation-bar" class="navbar navbar-default navbar-inverse navbar-fixed-top">


### PR DESCRIPTION
This PR adds the ability to define some JavaScript code for visitor tracking of Qiita. Raw code, i.e. contents of variable JS_CODE in config section user_tracking is injected as top element in of the sitebase.html template.

We, i.e. NFDI4Microbiota will use this mechanism to measure performance indicators.
